### PR TITLE
Initialize Node.js project with TypeScript

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database connection string
+DATABASE_URL=postgres://user:pass@localhost:5432/app_dev
+
+# JWT configuration
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRES_IN=1h
+
+# Application port
+PORT=3000

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "es6": true,
+    "node": true,
+    "jest": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2019,
+    "sourceType": "module"
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "plugins": ["@typescript-eslint", "prettier"],
+  "rules": {
+    "prettier/prettier": "error"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+.env
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: app_dev
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  app:
+    build: .
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://user:pass@db:5432/app_dev
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/usr/src/app
+    command: npm run dev
+volumes:
+  db_data:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "nvt-sync-space",
+  "version": "1.0.0",
+  "description": "> A Slack/Monday.com hybrid workspace combining real-time chat with lightweight project management for early adopters.",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "nodemon --watch \"src/**/*.ts\" --exec ts-node src/server.ts",
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.0",
+    "socket.io": "^4.7.0",
+    "pg": "^8.11.1",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.1",
+    "nodemon": "^3.0.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5",
+    "supertest": "^6.3.3",
+    "@types/supertest": "^2.0.12",
+    "@types/node": "^20.9.0",
+    "@types/express": "^4.17.21",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^6.13.2",
+    "@typescript-eslint/eslint-plugin": "^6.13.2",
+    "prettier": "^3.2.4",
+    "eslint-plugin-prettier": "^5.0.1",
+    "eslint-config-prettier": "^9.0.0"
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+
+const app = express();
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+export default app;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`); // eslint-disable-line no-console
+  });
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../src/server';
+
+describe('GET /health', () => {
+  it('responds with status ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Node project with TypeScript, Jest and linting
- add Dockerfile and docker-compose for Postgres
- provide example environment variables
- implement simple Express server with health check route
- add initial test for health endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b03e1bfd0832b887ab77676b619cf