### PR TITLE
Add organization CRUD and membership logic

### DIFF
--- a/src/contexts/organization/domain/Organization.ts
+++ b/src/contexts/organization/domain/Organization.ts
@@ -1,0 +1,17 @@
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Membership {
+  id: string;
+  userId: string;
+  organizationId: string;
+  role: 'admin' | 'member';
+  joinedAt: Date;
+}

--- a/src/contexts/organization/infrastructure/OrganizationRepository.ts
+++ b/src/contexts/organization/infrastructure/OrganizationRepository.ts
@@ -1,0 +1,117 @@
+import { v4 as uuid } from 'uuid';
+import { Organization, Membership } from '../domain/Organization';
+
+export class OrganizationRepository {
+  private organizations: Organization[] = [];
+  private memberships: Membership[] = [];
+
+  constructor() {
+    this.seedDefault();
+  }
+
+  private seedDefault(): void {
+    if (this.organizations.length === 0) {
+      const orgId = uuid();
+      const userId = 'admin-user';
+      const now = new Date();
+      this.organizations.push({
+        id: orgId,
+        name: 'Platform Workspace',
+        slug: 'platform-workspace',
+        description: 'Default organization',
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      this.memberships.push({
+        id: uuid(),
+        userId,
+        organizationId: orgId,
+        role: 'admin',
+        joinedAt: now,
+      });
+    }
+  }
+
+  async create(name: string, userId: string, description?: string): Promise<Organization> {
+    if (this.organizations.some(o => o.name.toLowerCase() === name.toLowerCase())) {
+      throw new Error('Organization name must be unique');
+    }
+    const now = new Date();
+    const organization: Organization = {
+      id: uuid(),
+      name,
+      slug: name.toLowerCase().replace(/\s+/g, '-'),
+      description,
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.organizations.push(organization);
+    this.memberships.push({
+      id: uuid(),
+      userId,
+      organizationId: organization.id,
+      role: 'admin',
+      joinedAt: now,
+    });
+    return organization;
+  }
+
+  async findAll(): Promise<Organization[]> {
+    return this.organizations.filter(o => o.isActive);
+  }
+
+  async findById(id: string): Promise<Organization | undefined> {
+    return this.organizations.find(o => o.id === id && o.isActive);
+  }
+
+  async update(id: string, data: Partial<Pick<Organization, 'name' | 'slug' | 'description'>>): Promise<Organization | undefined> {
+    const org = await this.findById(id);
+    if (!org) return undefined;
+    if (data.name && data.name !== org.name) {
+      if (this.organizations.some(o => o.name.toLowerCase() === data.name!.toLowerCase() && o.id !== id)) {
+        throw new Error('Organization name must be unique');
+      }
+      org.name = data.name;
+      org.slug = data.name.toLowerCase().replace(/\s+/g, '-');
+    }
+    if (data.slug) org.slug = data.slug;
+    if (data.description !== undefined) org.description = data.description;
+    org.updatedAt = new Date();
+    return org;
+  }
+
+  async delete(id: string): Promise<void> {
+    const org = await this.findById(id);
+    if (org) {
+      org.isActive = false;
+      org.updatedAt = new Date();
+    }
+  }
+
+  async listMembers(organizationId: string): Promise<Membership[]> {
+    return this.memberships.filter(m => m.organizationId === organizationId);
+  }
+
+  async addMember(organizationId: string, userId: string, role: 'admin' | 'member'): Promise<Membership> {
+    if (this.memberships.some(m => m.organizationId === organizationId && m.userId === userId)) {
+      throw new Error('User already member');
+    }
+    const membership: Membership = {
+      id: uuid(),
+      userId,
+      organizationId,
+      role,
+      joinedAt: new Date(),
+    };
+    this.memberships.push(membership);
+    return membership;
+  }
+
+  async removeMember(organizationId: string, userId: string): Promise<void> {
+    this.memberships = this.memberships.filter(m => !(m.organizationId === organizationId && m.userId === userId));
+  }
+}
+
+export const organizationRepository = new OrganizationRepository();

--- a/src/contexts/organization/presentation/router.ts
+++ b/src/contexts/organization/presentation/router.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { organizationRepository } from '../infrastructure/OrganizationRepository';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const orgs = await organizationRepository.findAll();
+  res.json(orgs);
+});
+
+router.post('/', async (req, res) => {
+  const { name, description, userId } = req.body;
+  if (!name || !userId) {
+    return res.status(400).json({ message: 'name and userId are required' });
+  }
+  try {
+    const org = await organizationRepository.create(name, userId, description);
+    res.status(201).json(org);
+  } catch (err) {
+    res.status(400).json({ message: (err as Error).message });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  const org = await organizationRepository.findById(req.params.id);
+  if (!org) return res.status(404).end();
+  res.json(org);
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const org = await organizationRepository.update(req.params.id, req.body);
+    if (!org) return res.status(404).end();
+    res.json(org);
+  } catch (err) {
+    res.status(400).json({ message: (err as Error).message });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  await organizationRepository.delete(req.params.id);
+  res.status(204).end();
+});
+
+router.get('/:id/members', async (req, res) => {
+  const members = await organizationRepository.listMembers(req.params.id);
+  res.json(members);
+});
+
+router.post('/:id/members', async (req, res) => {
+  const { userId, role } = req.body;
+  if (!userId || !role) return res.status(400).json({ message: 'userId and role are required' });
+  try {
+    const m = await organizationRepository.addMember(req.params.id, userId, role);
+    res.status(201).json(m);
+  } catch (err) {
+    res.status(400).json({ message: (err as Error).message });
+  }
+});
+
+router.delete('/:id/members/:userId', async (req, res) => {
+  await organizationRepository.removeMember(req.params.id, req.params.userId);
+  res.status(204).end();
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,15 @@
 import express from 'express';
+import organizationRouter from './contexts/organization/presentation/router';
 
 const app = express();
+
+app.use(express.json());
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
+
+app.use('/organizations', organizationRouter);
 
 export default app;
 

--- a/src/tests/integration/organization/organization.test.ts
+++ b/src/tests/integration/organization/organization.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import app from '../../../server';
+import { organizationRepository } from '../../../contexts/organization/infrastructure/OrganizationRepository';
+
+describe('Organization API', () => {
+  it('creates organization with admin membership', async () => {
+    const res = await request(app)
+      .post('/organizations')
+      .send({ name: 'Test Org', userId: 'u1', description: 'desc' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Test Org');
+
+    const members = await organizationRepository.listMembers(res.body.id);
+    const member = members.find(m => m.userId === 'u1');
+    expect(member?.role).toBe('admin');
+  });
+
+  it('prevents duplicate organization names', async () => {
+    const res = await request(app)
+      .post('/organizations')
+      .send({ name: 'Test Org', userId: 'u2' });
+    expect(res.status).toBe(400);
+  });
+
+  it('supports CRUD operations', async () => {
+    const create = await request(app)
+      .post('/organizations')
+      .send({ name: 'Org2', userId: 'u3' });
+    const id = create.body.id;
+
+    const get = await request(app).get(`/organizations/${id}`);
+    expect(get.status).toBe(200);
+    expect(get.body.name).toBe('Org2');
+
+    const update = await request(app)
+      .put(`/organizations/${id}`)
+      .send({ description: 'updated' });
+    expect(update.status).toBe(200);
+    expect(update.body.description).toBe('updated');
+
+    const del = await request(app).delete(`/organizations/${id}`);
+    expect(del.status).toBe(204);
+
+    const afterDelete = await request(app).get(`/organizations/${id}`);
+    expect(afterDelete.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add Organization domain model
- implement in-memory OrganizationRepository with default seed
- expose organization routes for CRUD and membership management
- wire router in Express server
- add integration tests for organizations

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684b3b854ea8832b805980151212479f