### PR TITLE
Add auth middleware and request validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database connection string
 DATABASE_URL=postgres://user:pass@localhost:5432/app_dev
+DB_POOL_SIZE=10
 
 # JWT configuration
 JWT_SECRET=your_jwt_secret

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "express": "^4.18.0",
     "socket.io": "^4.7.0",
     "pg": "^8.11.1",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "jsonwebtoken": "^9.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "typescript": "^5.3.3",
@@ -33,6 +35,7 @@
     "@types/node": "^20.9.0",
     "@types/express": "^4.17.21",
     "@types/pg": "^8.10.9",
+    "@types/jsonwebtoken": "^9.0.2",
     "eslint": "^8.56.0",
     "@typescript-eslint/parser": "^6.13.2",
     "@typescript-eslint/eslint-plugin": "^6.13.2",

--- a/src/contexts/auth/application/services/AuthService.ts
+++ b/src/contexts/auth/application/services/AuthService.ts
@@ -1,0 +1,19 @@
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { UserRepository } from '../../domain/repositories/UserRepository';
+
+export class AuthService {
+  constructor(private readonly userRepo: UserRepository) {}
+
+  async authenticate(email: string, password: string): Promise<string | null> {
+    const user = await this.userRepo.findByEmail(email);
+    if (!user) return null;
+    const matches = await bcrypt.compare(password, user.passwordHash);
+    if (!matches) return null;
+    return jwt.sign(
+      { userId: user.id, email: user.email },
+      process.env.JWT_SECRET as string,
+      { expiresIn: process.env.JWT_EXPIRES_IN || '1h' }
+    );
+  }
+}

--- a/src/contexts/auth/domain/entities/User.ts
+++ b/src/contexts/auth/domain/entities/User.ts
@@ -1,0 +1,10 @@
+export interface User {
+  id: string;
+  email: string;
+  passwordHash: string;
+}
+
+export interface UserPayload {
+  userId: string;
+  email: string;
+}

--- a/src/contexts/auth/domain/repositories/UserRepository.ts
+++ b/src/contexts/auth/domain/repositories/UserRepository.ts
@@ -1,0 +1,7 @@
+import { User } from '../entities/User';
+
+export interface UserRepository {
+  findById(id: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  create(user: User): Promise<User>;
+}

--- a/src/contexts/auth/infrastructure/UserRepositoryPg.ts
+++ b/src/contexts/auth/infrastructure/UserRepositoryPg.ts
@@ -1,0 +1,36 @@
+import { Pool } from 'pg';
+import { User } from '../domain/entities/User';
+import { UserRepository } from '../domain/repositories/UserRepository';
+
+export class UserRepositoryPg implements UserRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findById(id: string): Promise<User | null> {
+    const res = await this.pool.query(
+      'SELECT id, email, password_hash FROM users WHERE id = $1',
+      [id]
+    );
+    if (res.rowCount === 0) return null;
+    const row = res.rows[0];
+    return { id: row.id, email: row.email, passwordHash: row.password_hash };
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const res = await this.pool.query(
+      'SELECT id, email, password_hash FROM users WHERE email = $1',
+      [email]
+    );
+    if (res.rowCount === 0) return null;
+    const row = res.rows[0];
+    return { id: row.id, email: row.email, passwordHash: row.password_hash };
+  }
+
+  async create(user: User): Promise<User> {
+    const res = await this.pool.query(
+      'INSERT INTO users (id, email, password_hash) VALUES ($1, $2, $3) RETURNING id, email, password_hash',
+      [user.id, user.email, user.passwordHash]
+    );
+    const row = res.rows[0];
+    return { id: row.id, email: row.email, passwordHash: row.password_hash };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,25 @@
 import express from 'express';
+import { authenticate } from './shared/middleware/auth';
+import { validate } from './shared/middleware/validate';
+import { z } from 'zod';
 
 const app = express();
+app.use(express.json());
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
+});
+
+app.get('/protected', authenticate, (req, res) => {
+  res.json({ userId: req.user?.id });
+});
+
+const echoSchema = z.object({
+  message: z.string(),
+});
+
+app.post('/echo', validate(echoSchema), (req, res) => {
+  res.json({ message: req.body.message });
 });
 
 export default app;

--- a/src/shared/database/connection.ts
+++ b/src/shared/database/connection.ts
@@ -5,6 +5,7 @@ dotenv.config();
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  max: parseInt(process.env.DB_POOL_SIZE || '10', 10),
 });
 
 export default pool;

--- a/src/shared/middleware/auth.ts
+++ b/src/shared/middleware/auth.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+interface JwtPayload {
+  userId: string;
+  email: string;
+}
+
+export function authenticate(req: Request, res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET as string) as JwtPayload;
+    req.user = { id: payload.userId, email: payload.email };
+    next();
+  } catch {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}

--- a/src/shared/middleware/validate.ts
+++ b/src/shared/middleware/validate.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema } from 'zod';
+
+export function validate(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      res.status(400).json({ errors: result.error.format() });
+      return;
+    }
+    req.body = result.data;
+    next();
+  };
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  namespace Express {
+    interface Request {
+      user?: { id: string; email: string };
+    }
+  }
+}
+
+export {};

--- a/tests/integration/authMiddleware.test.ts
+++ b/tests/integration/authMiddleware.test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../../src/server';
+
+describe('authentication middleware', () => {
+  const secret = 'testsecret';
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = secret;
+  });
+
+  it('allows access with valid token', async () => {
+    const token = jwt.sign({ userId: '123', email: 'test@example.com' }, secret);
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ userId: '123' });
+  });
+
+  it('rejects invalid token', async () => {
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer invalid');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/validation.test.ts
+++ b/tests/integration/validation.test.ts
@@ -1,0 +1,19 @@
+import request from 'supertest';
+import app from '../../src/server';
+
+describe('validation middleware', () => {
+  it('returns 400 for invalid data', async () => {
+    const res = await request(app)
+      .post('/echo')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('passes with valid data', async () => {
+    const res = await request(app)
+      .post('/echo')
+      .send({ message: 'hello' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'hello' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement JWT authentication middleware
- add request body validation helper with Zod
- provide database pool configuration via env vars
- scaffold auth context with repository interface and PG implementation
- expose auth service for issuing JWTs
- add sample protected and validation routes
- extend `.env.example` and dependencies
- test middleware behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b30f319b8832b9a37917356e76eb1