### PR TITLE
Implement organization CRUD and membership

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
+  globalSetup: './tests/setup.ts',
 };

--- a/src/contexts/organization/application/OrganizationService.ts
+++ b/src/contexts/organization/application/OrganizationService.ts
@@ -1,0 +1,38 @@
+import { IOrganizationRepository } from '../domain/IOrganizationRepository';
+import { Organization } from '../domain/Organization';
+
+export default class OrganizationService {
+  constructor(private readonly repo: IOrganizationRepository) {}
+
+  async createOrganization(name: string, description: string | undefined, userId: string): Promise<Organization> {
+    const existing = await this.repo.findByName(name);
+    if (existing) {
+      throw new Error('Organization name already exists');
+    }
+    return this.repo.create(name, description, userId);
+  }
+
+  async listOrganizations(userId: string) {
+    return this.repo.listForUser(userId);
+  }
+
+  async getOrganization(id: string) {
+    return this.repo.findById(id);
+  }
+
+  async updateOrganization(id: string, name: string, description: string | undefined) {
+    return this.repo.update(id, name, description);
+  }
+
+  async deleteOrganization(id: string) {
+    await this.repo.delete(id);
+  }
+
+  async addMember(orgId: string, userId: string, role: string) {
+    await this.repo.addMember(orgId, userId, role);
+  }
+
+  async removeMember(orgId: string, userId: string) {
+    await this.repo.removeMember(orgId, userId);
+  }
+}

--- a/src/contexts/organization/domain/IOrganizationRepository.ts
+++ b/src/contexts/organization/domain/IOrganizationRepository.ts
@@ -1,0 +1,17 @@
+import { Organization } from './Organization';
+
+export interface OrganizationWithRole extends Organization {
+  role: string;
+  joinedAt: Date;
+}
+
+export interface IOrganizationRepository {
+  create(name: string, description: string | undefined, userId: string): Promise<Organization>;
+  findById(id: string): Promise<Organization | null>;
+  findByName(name: string): Promise<Organization | null>;
+  listForUser(userId: string): Promise<OrganizationWithRole[]>;
+  update(id: string, name: string, description: string | undefined): Promise<Organization | null>;
+  delete(id: string): Promise<void>;
+  addMember(orgId: string, userId: string, role: string): Promise<void>;
+  removeMember(orgId: string, userId: string): Promise<void>;
+}

--- a/src/contexts/organization/domain/Organization.ts
+++ b/src/contexts/organization/domain/Organization.ts
@@ -1,0 +1,9 @@
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string | null;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/contexts/organization/domain/UserOrganization.ts
+++ b/src/contexts/organization/domain/UserOrganization.ts
@@ -1,0 +1,7 @@
+export interface UserOrganization {
+  id: string;
+  userId: string;
+  organizationId: string;
+  role: string;
+  joinedAt: Date;
+}

--- a/src/contexts/organization/infrastructure/OrganizationRepositoryPg.ts
+++ b/src/contexts/organization/infrastructure/OrganizationRepositoryPg.ts
@@ -1,0 +1,77 @@
+import sql from 'sql-template-strings';
+import pool from '../../../shared/database/connection';
+import { IOrganizationRepository, OrganizationWithRole } from '../domain/IOrganizationRepository';
+import { Organization } from '../domain/Organization';
+
+export default class OrganizationRepositoryPg implements IOrganizationRepository {
+  async create(name: string, description: string | undefined, userId: string): Promise<Organization> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const slug = name.toLowerCase().replace(/\s+/g, '-');
+      const orgRes = await client.query<Organization>(
+        sql`INSERT INTO organizations (name, slug, description)
+            VALUES (${name}, ${slug}, ${description})
+            RETURNING *`,
+      );
+      const org = orgRes.rows[0];
+      await client.query(
+        sql`INSERT INTO user_organizations (user_id, organization_id, role)
+            VALUES (${userId}, ${org.id}, 'admin')`,
+      );
+      await client.query('COMMIT');
+      return org;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async findById(id: string): Promise<Organization | null> {
+    const res = await pool.query<Organization>(sql`SELECT * FROM organizations WHERE id = ${id}`);
+    return res.rows[0] || null;
+  }
+
+  async findByName(name: string): Promise<Organization | null> {
+    const res = await pool.query<Organization>(sql`SELECT * FROM organizations WHERE name = ${name}`);
+    return res.rows[0] || null;
+  }
+
+  async listForUser(userId: string): Promise<OrganizationWithRole[]> {
+    const res = await pool.query<OrganizationWithRole>(sql`
+      SELECT o.*, uo.role, uo.joined_at AS "joinedAt"
+      FROM organizations o
+      JOIN user_organizations uo ON uo.organization_id = o.id
+      WHERE uo.user_id = ${userId}
+    `);
+    return res.rows;
+  }
+
+  async update(id: string, name: string, description: string | undefined): Promise<Organization | null> {
+    const slug = name.toLowerCase().replace(/\s+/g, '-');
+    const res = await pool.query<Organization>(
+      sql`UPDATE organizations SET name=${name}, slug=${slug}, description=${description}, updated_at=NOW()
+          WHERE id=${id}
+          RETURNING *`,
+    );
+    return res.rows[0] || null;
+  }
+
+  async delete(id: string): Promise<void> {
+    await pool.query(sql`DELETE FROM organizations WHERE id = ${id}`);
+  }
+
+  async addMember(orgId: string, userId: string, role: string): Promise<void> {
+    await pool.query(
+      sql`INSERT INTO user_organizations (user_id, organization_id, role)
+          VALUES (${userId}, ${orgId}, ${role})
+          ON CONFLICT (user_id, organization_id) DO UPDATE SET role = EXCLUDED.role`,
+    );
+  }
+
+  async removeMember(orgId: string, userId: string): Promise<void> {
+    await pool.query(sql`DELETE FROM user_organizations WHERE organization_id=${orgId} AND user_id=${userId}`);
+  }
+}

--- a/src/contexts/organization/presentation/organizationRoutes.ts
+++ b/src/contexts/organization/presentation/organizationRoutes.ts
@@ -1,0 +1,64 @@
+import { Router } from 'express';
+import OrganizationService from '../application/OrganizationService';
+import OrganizationRepositoryPg from '../infrastructure/OrganizationRepositoryPg';
+
+const repo = new OrganizationRepositoryPg();
+const service = new OrganizationService(repo);
+
+const router = Router();
+
+// Middleware to extract userId from header for simplicity
+router.use((req, res, next) => {
+  const userId = req.header('x-user-id');
+  if (!userId) {
+    return res.status(400).json({ error: 'Missing user id' });
+  }
+  (req as any).userId = userId;
+  next();
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const org = await service.createOrganization(name, description, (req as any).userId);
+    res.status(201).json(org);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.get('/', async (req, res) => {
+  const orgs = await service.listOrganizations((req as any).userId);
+  res.json({ organizations: orgs });
+});
+
+router.get('/:id', async (req, res) => {
+  const org = await service.getOrganization(req.params.id);
+  if (!org) return res.status(404).end();
+  res.json(org);
+});
+
+router.put('/:id', async (req, res) => {
+  const { name, description } = req.body;
+  const updated = await service.updateOrganization(req.params.id, name, description);
+  if (!updated) return res.status(404).end();
+  res.json(updated);
+});
+
+router.delete('/:id', async (req, res) => {
+  await service.deleteOrganization(req.params.id);
+  res.status(204).end();
+});
+
+router.post('/:id/members', async (req, res) => {
+  const { userId, role } = req.body;
+  await service.addMember(req.params.id, userId, role || 'member');
+  res.status(204).end();
+});
+
+router.delete('/:id/members/:userId', async (req, res) => {
+  await service.removeMember(req.params.id, req.params.userId);
+  res.status(204).end();
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,14 @@
 import express from 'express';
+import organizationRoutes from './contexts/organization/presentation/organizationRoutes';
 
 const app = express();
+app.use(express.json());
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
+
+app.use('/v1/orgs', organizationRoutes);
 
 export default app;
 

--- a/tests/integration/organization.test.ts
+++ b/tests/integration/organization.test.ts
@@ -1,0 +1,77 @@
+import request from 'supertest';
+import app from '../../src/server';
+import pool from '../../src/shared/database/connection';
+
+async function createUser(email: string) {
+  const res = await pool.query(
+    `INSERT INTO users (email, password_hash, first_name, last_name)
+     VALUES ($1, 'hash', 'Test', 'User') RETURNING id`,
+    [email],
+  );
+  return res.rows[0].id as string;
+}
+
+describe('Organization CRUD', () => {
+  let userId: string;
+
+  beforeAll(async () => {
+    userId = await createUser('testuser@example.com');
+  });
+
+  it('creates organization and assigns admin role', async () => {
+    const res = await request(app)
+      .post('/v1/orgs')
+      .set('x-user-id', userId)
+      .send({ name: 'Test Org', description: 'desc' });
+    expect(res.status).toBe(201);
+    const orgId = res.body.id;
+    const roleRes = await pool.query(
+      'SELECT role FROM user_organizations WHERE user_id=$1 AND organization_id=$2',
+      [userId, orgId],
+    );
+    expect(roleRes.rows[0].role).toBe('admin');
+  });
+
+  it('enforces unique organization names', async () => {
+    const res = await request(app)
+      .post('/v1/orgs')
+      .set('x-user-id', userId)
+      .send({ name: 'Test Org' });
+    expect(res.status).toBe(400);
+  });
+
+  it('updates and deletes organization', async () => {
+    const create = await request(app)
+      .post('/v1/orgs')
+      .set('x-user-id', userId)
+      .send({ name: 'Org To Update' });
+    const id = create.body.id;
+    const update = await request(app)
+      .put(`/v1/orgs/${id}`)
+      .set('x-user-id', userId)
+      .send({ name: 'Updated Org' });
+    expect(update.body.name).toBe('Updated Org');
+    await request(app).delete(`/v1/orgs/${id}`).set('x-user-id', userId);
+    const get = await request(app).get(`/v1/orgs/${id}`).set('x-user-id', userId);
+    expect(get.status).toBe(404);
+  });
+
+  it('adds member with specified role', async () => {
+    const otherUser = await createUser('member@example.com');
+    const create = await request(app)
+      .post('/v1/orgs')
+      .set('x-user-id', userId)
+      .send({ name: 'Org With Member' });
+    const orgId = create.body.id;
+    await request(app)
+      .post(`/v1/orgs/${orgId}/members`)
+      .set('x-user-id', userId)
+      .send({ userId: otherUser, role: 'member' })
+      .expect(204);
+    const roleRes = await pool.query(
+      'SELECT role FROM user_organizations WHERE user_id=$1 AND organization_id=$2',
+      [otherUser, orgId],
+    );
+    expect(roleRes.rows[0].role).toBe('member');
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,6 @@
+import { execSync } from 'child_process';
+
+module.exports = async () => {
+  execSync('npx node-pg-migrate up', { stdio: 'inherit' });
+  execSync('ts-node src/shared/database/seeds/seed.ts', { stdio: 'inherit' });
+};


### PR DESCRIPTION
## Summary
- implement organization service, repository, and domain entities
- add express routes for organization CRUD and membership
- register routes in server
- configure Jest global setup for migrations and seeds
- add integration tests for organization flows

## Testing
- `npx tsc -p tsconfig.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b30d84ecc832b9e4145d30a7ffd32