### PR TITLE
Add chat entities and websocket handling

### DIFF
--- a/src/contexts/chat/domain/Channel.ts
+++ b/src/contexts/chat/domain/Channel.ts
@@ -1,0 +1,10 @@
+export interface Channel {
+  id: string;
+  organizationId: string;
+  name: string;
+  description: string | null;
+  isPrivate: boolean;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/contexts/chat/domain/Message.ts
+++ b/src/contexts/chat/domain/Message.ts
@@ -1,0 +1,11 @@
+export interface Message {
+  id: string;
+  channelId: string;
+  userId: string;
+  content: string;
+  messageType: string;
+  replyToId: string | null;
+  isEdited: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/contexts/chat/domain/Reaction.ts
+++ b/src/contexts/chat/domain/Reaction.ts
@@ -1,0 +1,7 @@
+export interface Reaction {
+  id: string;
+  messageId: string;
+  userId: string;
+  emoji: string;
+  createdAt: Date;
+}

--- a/src/contexts/chat/infrastructure/channelRepository.ts
+++ b/src/contexts/chat/infrastructure/channelRepository.ts
@@ -1,0 +1,33 @@
+import { Pool } from 'pg';
+import { Channel } from '../domain/Channel';
+
+export class ChannelRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async createChannel(
+    organizationId: string,
+    name: string,
+    description: string | null,
+    isPrivate: boolean,
+    createdBy: string,
+  ): Promise<Channel> {
+    const result = await this.pool.query<Channel>(
+      `INSERT INTO channels (organization_id, name, description, is_private, created_by)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [organizationId, name, description, isPrivate, createdBy],
+    );
+    const channel = result.rows[0];
+    await this.addMember(channel.id, createdBy);
+    return channel;
+  }
+
+  async addMember(channelId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO channel_members (channel_id, user_id)
+       VALUES ($1, $2)
+       ON CONFLICT (channel_id, user_id) DO NOTHING`,
+      [channelId, userId],
+    );
+  }
+}

--- a/src/contexts/chat/infrastructure/messageRepository.ts
+++ b/src/contexts/chat/infrastructure/messageRepository.ts
@@ -1,0 +1,29 @@
+import { Pool } from 'pg';
+import { Message } from '../domain/Message';
+
+export class MessageRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async createMessage(
+    channelId: string,
+    userId: string,
+    content: string,
+    replyToId?: string,
+  ): Promise<Message> {
+    const result = await this.pool.query<Message>(
+      `INSERT INTO messages (channel_id, user_id, content, reply_to_id)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [channelId, userId, content, replyToId || null],
+    );
+    return result.rows[0];
+  }
+
+  async getMessageById(id: string): Promise<Message> {
+    const result = await this.pool.query<Message>(
+      'SELECT * FROM messages WHERE id = $1',
+      [id],
+    );
+    return result.rows[0];
+  }
+}

--- a/src/contexts/chat/infrastructure/reactionRepository.ts
+++ b/src/contexts/chat/infrastructure/reactionRepository.ts
@@ -1,0 +1,20 @@
+import { Pool } from 'pg';
+import { Reaction } from '../domain/Reaction';
+
+export class ReactionRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async addReaction(
+    messageId: string,
+    userId: string,
+    emoji: string,
+  ): Promise<Reaction> {
+    const result = await this.pool.query<Reaction>(
+      `INSERT INTO message_reactions (message_id, user_id, emoji)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [messageId, userId, emoji],
+    );
+    return result.rows[0];
+  }
+}

--- a/src/contexts/chat/presentation/routes.ts
+++ b/src/contexts/chat/presentation/routes.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { ChannelRepository } from '../infrastructure/channelRepository';
+import { MessageRepository } from '../infrastructure/messageRepository';
+
+export function createChatRouter(
+  channelRepo: ChannelRepository,
+  messageRepo: MessageRepository,
+): Router {
+  const router = Router({ mergeParams: true });
+
+  router.post('/', async (req, res) => {
+    const { orgId } = req.params;
+    const { name, description, isPrivate, userId } = req.body;
+    const channel = await channelRepo.createChannel(
+      orgId,
+      name,
+      description || null,
+      Boolean(isPrivate),
+      userId,
+    );
+    res.status(201).json(channel);
+  });
+
+  router.post('/:channelId/messages', async (req, res) => {
+    const { channelId } = req.params;
+    const { userId, content } = req.body;
+    const message = await messageRepo.createMessage(channelId, userId, content);
+    res.status(201).json(message);
+  });
+
+  return router;
+}

--- a/src/contexts/chat/presentation/socket.ts
+++ b/src/contexts/chat/presentation/socket.ts
@@ -1,0 +1,39 @@
+import { Server, Socket } from 'socket.io';
+import { MessageRepository } from '../infrastructure/messageRepository';
+import { ReactionRepository } from '../infrastructure/reactionRepository';
+
+export function initChatSocket(
+  io: Server,
+  messageRepo: MessageRepository,
+  reactionRepo: ReactionRepository,
+): void {
+  io.of(/^\/org\/\w+$/).on('connection', (socket: Socket) => {
+    socket.on('joinChannel', (channelId: string) => {
+      socket.join(`channel:${channelId}`);
+    });
+
+    socket.on('typing', data => {
+      const room = `channel:${data.channelId}`;
+      socket.to(room).emit('typing', { channelId: data.channelId, userId: data.userId });
+    });
+
+    socket.on('postMessage', async data => {
+      const message = await messageRepo.createMessage(
+        data.channelId,
+        data.userId,
+        data.content,
+      );
+      io.to(`channel:${data.channelId}`).emit('newMessage', message);
+    });
+
+    socket.on('addReaction', async data => {
+      const reaction = await reactionRepo.addReaction(
+        data.messageId,
+        data.userId,
+        data.emoji,
+      );
+      const message = await messageRepo.getMessageById(data.messageId);
+      io.to(`channel:${message.channelId}`).emit('reactionAdded', reaction);
+    });
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,42 @@
 import express from 'express';
+import http from 'http';
+import { Server as IOServer } from 'socket.io';
+import pool from './shared/database/connection';
+import { logger } from './shared/middleware/logger';
+import { ChannelRepository } from './contexts/chat/infrastructure/channelRepository';
+import { MessageRepository } from './contexts/chat/infrastructure/messageRepository';
+import { ReactionRepository } from './contexts/chat/infrastructure/reactionRepository';
+import { createChatRouter } from './contexts/chat/presentation/routes';
+import { initChatSocket } from './contexts/chat/presentation/socket';
 
-const app = express();
+export function createApp() {
+  const app = express();
+  app.use(logger);
+  app.use(express.json());
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
-});
+  const channelRepo = new ChannelRepository(pool);
+  const messageRepo = new MessageRepository(pool);
+  const reactionRepo = new ReactionRepository(pool);
 
+  app.use('/org/:orgId/channels', createChatRouter(channelRepo, messageRepo));
+
+  const server = http.createServer(app);
+  const io = new IOServer(server);
+  initChatSocket(io, messageRepo, reactionRepo);
+
+  return { app, server, io };
+}
+
+const { app, server } = createApp();
 export default app;
+export { server };
 
 if (require.main === module) {
   const port = process.env.PORT || 3000;
-  app.listen(port, () => {
+  server.listen(port, () => {
     console.log(`Server running on port ${port}`); // eslint-disable-line no-console
   });
 }

--- a/tests/helpers/inMemoryRepos.ts
+++ b/tests/helpers/inMemoryRepos.ts
@@ -1,0 +1,83 @@
+import { Channel } from '../../src/contexts/chat/domain/Channel';
+import { Message } from '../../src/contexts/chat/domain/Message';
+import { Reaction } from '../../src/contexts/chat/domain/Reaction';
+
+export class InMemoryChannelRepository {
+  public channels: Channel[] = [];
+  public members: Record<string, Set<string>> = {};
+
+  async createChannel(
+    organizationId: string,
+    name: string,
+    description: string | null,
+    isPrivate: boolean,
+    createdBy: string,
+  ): Promise<Channel> {
+    const channel: Channel = {
+      id: `ch-${this.channels.length + 1}`,
+      organizationId,
+      name,
+      description,
+      isPrivate,
+      createdBy,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.channels.push(channel);
+    await this.addMember(channel.id, createdBy);
+    return channel;
+  }
+
+  async addMember(channelId: string, userId: string): Promise<void> {
+    if (!this.members[channelId]) this.members[channelId] = new Set();
+    this.members[channelId].add(userId);
+  }
+}
+
+export class InMemoryMessageRepository {
+  public messages: Message[] = [];
+
+  async createMessage(
+    channelId: string,
+    userId: string,
+    content: string,
+  ): Promise<Message> {
+    const message: Message = {
+      id: `m-${this.messages.length + 1}`,
+      channelId,
+      userId,
+      content,
+      messageType: 'text',
+      replyToId: null,
+      isEdited: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.messages.push(message);
+    return message;
+  }
+
+  async getMessageById(id: string): Promise<Message> {
+    return this.messages.find(m => m.id === id)!;
+  }
+}
+
+export class InMemoryReactionRepository {
+  public reactions: Reaction[] = [];
+
+  async addReaction(
+    messageId: string,
+    userId: string,
+    emoji: string,
+  ): Promise<Reaction> {
+    const reaction: Reaction = {
+      id: `r-${this.reactions.length + 1}`,
+      messageId,
+      userId,
+      emoji,
+      createdAt: new Date(),
+    };
+    this.reactions.push(reaction);
+    return reaction;
+  }
+}

--- a/tests/unit/channel.autosub.test.ts
+++ b/tests/unit/channel.autosub.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import express from 'express';
+import { createChatRouter } from '../../src/contexts/chat/presentation/routes';
+import {
+  InMemoryChannelRepository,
+  InMemoryMessageRepository,
+} from '../helpers/inMemoryRepos';
+
+describe('channel creation', () => {
+  it('adds creator as member', async () => {
+    const channelRepo = new InMemoryChannelRepository();
+    const messageRepo = new InMemoryMessageRepository();
+    const app = express();
+    app.use(express.json());
+    app.use('/org/:orgId/channels', createChatRouter(channelRepo, messageRepo));
+
+    const res = await request(app)
+      .post('/org/org1/channels')
+      .send({ name: 'dev', description: '', isPrivate: false, userId: 'u1' });
+
+    expect(res.status).toBe(201);
+    const channelId = res.body.id;
+    expect(channelRepo.members[channelId].has('u1')).toBe(true);
+  });
+});

--- a/tests/unit/socket.flow.test.ts
+++ b/tests/unit/socket.flow.test.ts
@@ -1,0 +1,31 @@
+import { initChatSocket } from '../../src/contexts/chat/presentation/socket';
+import { InMemoryMessageRepository, InMemoryReactionRepository } from '../helpers/inMemoryRepos';
+
+describe('socket message flow', () => {
+  it('emits newMessage to room on postMessage', async () => {
+    const messageRepo = new InMemoryMessageRepository();
+    const reactionRepo = new InMemoryReactionRepository();
+
+    const emitMock = jest.fn();
+    const io = {
+      of: jest.fn(() => ({ on: (event: string, cb: any) => { connectionCb = cb; } })),
+      to: jest.fn(() => ({ emit: emitMock })),
+    } as any;
+
+    let connectionCb: any;
+    initChatSocket(io, messageRepo as any, reactionRepo as any);
+
+    const socketHandlers: Record<string, any> = {};
+    const socket = {
+      on: (event: string, cb: any) => { socketHandlers[event] = cb; },
+      join: jest.fn(),
+      to: jest.fn(() => ({ emit: jest.fn() })),
+    } as any;
+
+    connectionCb(socket);
+
+    await socketHandlers['postMessage']({ channelId: 'c1', userId: 'u1', content: 'hi' });
+
+    expect(emitMock).toHaveBeenCalledWith('newMessage', expect.objectContaining({ content: 'hi' }));
+  });
+});


### PR DESCRIPTION
## Summary
- implement Channel, Message, and Reaction domain models
- implement repositories for channels, messages, and reactions
- expose REST routes for channels and messages
- add websocket namespace per organization with events for messages, typing and reactions
- set up in-memory repositories for unit tests
- test auto-membership on channel creation and websocket message broadcasts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b30d9f3d0832b9c08d5724d84a7b3