### PR TITLE
Add project management basics

### DIFF
--- a/src/contexts/project/domain/models.ts
+++ b/src/contexts/project/domain/models.ts
@@ -1,0 +1,40 @@
+export interface Board {
+  id: string;
+  organizationId: string;
+  name: string;
+  description?: string | null;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Column {
+  id: string;
+  boardId: string;
+  name: string;
+  position: number;
+  createdAt: Date;
+}
+
+export interface Issue {
+  id: string;
+  boardId: string;
+  columnId: string;
+  title: string;
+  description?: string | null;
+  assignedTo?: string | null;
+  priority: string;
+  position: number;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IssueComment {
+  id: string;
+  issueId: string;
+  userId: string;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/contexts/project/infrastructure/projectRepository.ts
+++ b/src/contexts/project/infrastructure/projectRepository.ts
@@ -1,0 +1,116 @@
+import pool from '../../../shared/database/connection';
+import { Board, Column, Issue, IssueComment } from '../domain/models';
+
+export async function createBoard(
+  orgId: string,
+  name: string,
+  description: string | null,
+  userId: string,
+): Promise<{ board: Board; columns: Column[] }> {
+  const boardRes = await pool.query<Board>(
+    `INSERT INTO boards (organization_id, name, description, created_by)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [orgId, name, description, userId],
+  );
+  const board = boardRes.rows[0];
+
+  const columns: Column[] = [];
+  const columnNames = ['Backlog', 'In Progress', 'Done'];
+  for (let i = 0; i < columnNames.length; i += 1) {
+    const colRes = await pool.query<Column>(
+      `INSERT INTO columns (board_id, name, position)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [board.id, columnNames[i], i + 1],
+    );
+    columns.push(colRes.rows[0]);
+  }
+
+  return { board, columns };
+}
+
+export async function listBoards(orgId: string): Promise<Board[]> {
+  const res = await pool.query<Board>(
+    'SELECT * FROM boards WHERE organization_id = $1 ORDER BY created_at',
+    [orgId],
+  );
+  return res.rows;
+}
+
+export async function getBoard(orgId: string, boardId: string): Promise<Board & { columns: Column[] }> {
+  const boardRes = await pool.query<Board>(
+    'SELECT * FROM boards WHERE id = $1 AND organization_id = $2',
+    [boardId, orgId],
+  );
+  const board = boardRes.rows[0];
+  const colRes = await pool.query<Column>(
+    'SELECT * FROM columns WHERE board_id = $1 ORDER BY position',
+    [boardId],
+  );
+  return { ...board, columns: colRes.rows };
+}
+
+export async function updateBoard(
+  orgId: string,
+  boardId: string,
+  name: string,
+  description: string | null,
+): Promise<Board> {
+  const res = await pool.query<Board>(
+    `UPDATE boards
+     SET name = $1, description = $2, updated_at = NOW()
+     WHERE id = $3 AND organization_id = $4
+     RETURNING *`,
+    [name, description, boardId, orgId],
+  );
+  return res.rows[0];
+}
+
+export async function deleteBoard(orgId: string, boardId: string): Promise<void> {
+  await pool.query('DELETE FROM boards WHERE id = $1 AND organization_id = $2', [boardId, orgId]);
+}
+
+export async function createIssue(
+  boardId: string,
+  columnId: string,
+  title: string,
+  description: string | null,
+  assignedTo: string | null,
+  priority: string,
+  userId: string,
+): Promise<Issue> {
+  const posRes = await pool.query<{ pos: number }>(
+    'SELECT COALESCE(MAX(position), 0) + 1 as pos FROM issues WHERE column_id = $1',
+    [columnId],
+  );
+
+  const res = await pool.query<Issue>(
+    `INSERT INTO issues (board_id, column_id, title, description, assigned_to, priority, position, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING *`,
+    [boardId, columnId, title, description, assignedTo, priority, posRes.rows[0].pos, userId],
+  );
+  return res.rows[0];
+}
+
+export async function moveIssue(issueId: string, columnId: string, position: number): Promise<Issue> {
+  const res = await pool.query<Issue>(
+    `UPDATE issues
+     SET column_id = $1, position = $2, updated_at = NOW()
+     WHERE id = $3
+     RETURNING *`,
+    [columnId, position, issueId],
+  );
+  return res.rows[0];
+}
+
+export async function addComment(issueId: string, userId: string, content: string): Promise<IssueComment> {
+  const res = await pool.query<IssueComment>(
+    `INSERT INTO issue_comments (issue_id, user_id, content)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [issueId, userId, content],
+  );
+  return res.rows[0];
+}

--- a/src/contexts/project/presentation/projectRoutes.ts
+++ b/src/contexts/project/presentation/projectRoutes.ts
@@ -1,0 +1,109 @@
+import { Router } from 'express';
+import {
+  createBoard,
+  listBoards,
+  getBoard,
+  updateBoard,
+  deleteBoard,
+  createIssue,
+  moveIssue,
+  addComment,
+} from '../infrastructure/projectRepository';
+
+const router = Router();
+
+router.post('/orgs/:orgId/boards', async (req, res, next) => {
+  try {
+    const { name, description } = req.body;
+    const { orgId } = req.params;
+    const userId = req.header('x-user') || '00000000-0000-0000-0000-000000000000';
+    const result = await createBoard(orgId, name, description ?? null, userId);
+    res.status(201).json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/orgs/:orgId/boards', async (req, res, next) => {
+  try {
+    const boards = await listBoards(req.params.orgId);
+    res.json({ boards });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/orgs/:orgId/boards/:boardId', async (req, res, next) => {
+  try {
+    const board = await getBoard(req.params.orgId, req.params.boardId);
+    res.json(board);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/orgs/:orgId/boards/:boardId', async (req, res, next) => {
+  try {
+    const { name, description } = req.body;
+    const board = await updateBoard(
+      req.params.orgId,
+      req.params.boardId,
+      name,
+      description ?? null,
+    );
+    res.json(board);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/orgs/:orgId/boards/:boardId', async (req, res, next) => {
+  try {
+    await deleteBoard(req.params.orgId, req.params.boardId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/orgs/:orgId/boards/:boardId/issues', async (req, res, next) => {
+  try {
+    const { columnId, title, description, assignedTo, priority } = req.body;
+    const userId = req.header('x-user') || '00000000-0000-0000-0000-000000000000';
+    const issue = await createIssue(
+      req.params.boardId,
+      columnId,
+      title,
+      description ?? null,
+      assignedTo ?? null,
+      priority ?? 'medium',
+      userId,
+    );
+    res.status(201).json(issue);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/orgs/:orgId/issues/:issueId/move', async (req, res, next) => {
+  try {
+    const { columnId, position } = req.body;
+    const issue = await moveIssue(req.params.issueId, columnId, position);
+    res.json(issue);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/orgs/:orgId/issues/:issueId/comments', async (req, res, next) => {
+  try {
+    const { content } = req.body;
+    const userId = req.header('x-user') || '00000000-0000-0000-0000-000000000000';
+    const comment = await addComment(req.params.issueId, userId, content);
+    res.status(201).json(comment);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,11 @@
 import express from 'express';
+import projectRoutes from './contexts/project/presentation/projectRoutes';
 
 const app = express();
+
+app.use(express.json());
+
+app.use('/v1', projectRoutes);
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/src/shared/database/seeds/007_seed_demo_issues.sql
+++ b/src/shared/database/seeds/007_seed_demo_issues.sql
@@ -1,0 +1,15 @@
+INSERT INTO issues (board_id, column_id, title, description, assigned_to, priority, position, created_by)
+SELECT b.id, c.id, 'Invite your team', 'Add teammates to start collaborating', u.id, 'medium', 1, u.id
+FROM boards b
+JOIN columns c ON c.board_id = b.id AND c.name = 'Backlog'
+JOIN users u ON u.email = 'admin@platform.com'
+WHERE b.name = 'Getting Started'
+ON CONFLICT (column_id, position) DO NOTHING;
+
+INSERT INTO issues (board_id, column_id, title, description, assigned_to, priority, position, created_by)
+SELECT b.id, c.id, 'Create your first task', 'Start tracking work items', u.id, 'medium', 2, u.id
+FROM boards b
+JOIN columns c ON c.board_id = b.id AND c.name = 'Backlog'
+JOIN users u ON u.email = 'admin@platform.com'
+WHERE b.name = 'Getting Started'
+ON CONFLICT (column_id, position) DO NOTHING;

--- a/src/shared/database/seeds/seed.ts
+++ b/src/shared/database/seeds/seed.ts
@@ -3,11 +3,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import 'dotenv/config';
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const defaultPool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-async function runSeeds(): Promise<void> {
+export async function runSeeds(pool: Pool = defaultPool): Promise<void> {
   const seedDir = __dirname;
-  const files = fs.readdirSync(seedDir)
+  const files = fs
+    .readdirSync(seedDir)
     .filter(f => f.match(/^\d+_.*\.sql$/))
     .sort();
 
@@ -18,12 +19,16 @@ async function runSeeds(): Promise<void> {
   }
 }
 
-runSeeds()
-  .then(() => {
-    console.log('Seeding complete'); // eslint-disable-line no-console
-    return pool.end();
-  })
-  .catch(err => {
-    console.error(err); // eslint-disable-line no-console
-    pool.end().then(() => process.exit(1));
-  });
+if (require.main === module) {
+  runSeeds()
+    .then(() => {
+      console.log('Seeding complete'); // eslint-disable-line no-console
+      return defaultPool.end();
+    })
+    .catch(err => {
+      console.error(err); // eslint-disable-line no-console
+      defaultPool.end().then(() => process.exit(1));
+    });
+}
+
+export default runSeeds;

--- a/tests/unit/issueLifecycle.test.ts
+++ b/tests/unit/issueLifecycle.test.ts
@@ -1,0 +1,23 @@
+jest.mock('../../src/shared/database/connection', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import pool from '../../src/shared/database/connection';
+import { moveIssue } from '../../src/contexts/project/infrastructure/projectRepository';
+
+const queryMock = pool.query as jest.Mock;
+
+describe('issue lifecycle', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('moves issue to new column', async () => {
+    queryMock.mockResolvedValue({ rows: [{ id: '1', column_id: 'col2', position: 2 }] });
+    const result = await moveIssue('1', 'col2', 2);
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('UPDATE issues'), ['col2', 2, '1']);
+    expect(result.column_id).toBe('col2');
+    expect(result.position).toBe(2);
+  });
+});

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -1,0 +1,19 @@
+import { runSeeds } from '../../src/shared/database/seeds/seed';
+
+const executed: string[] = [];
+
+const mockPool = {
+  query: async (sql: string) => {
+    executed.push(sql);
+    return { rows: [] };
+  },
+};
+
+describe('database seeds', () => {
+  it('loads demo board issues', async () => {
+    await runSeeds(mockPool as any);
+    const allSql = executed.join('\n');
+    expect(allSql).toContain('Getting Started');
+    expect(allSql).toContain('INSERT INTO issues');
+  });
+});


### PR DESCRIPTION
## Summary
- seed demo board with issues
- expose runSeeds helper for testing
- add minimal project repository and routes
- wire up project routes in server
- tests for seed loading and issue lifecycle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b30dcda70832ba98d1129be0fbdfb